### PR TITLE
ci: Add initial deploy job to workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   maven: circleci/maven@1.3.0
+  semantic-release: trustedshops-public/semantic-release@3.1.3
 
 executors:
   java8:
@@ -46,7 +47,7 @@ jobs:
         description: Suffix to append to version
     steps:
       - checkout
-      - maven/witch-cache:
+      - maven/with_cache:
           steps:
             - run:
                 name: Set version to latest tag
@@ -82,4 +83,12 @@ workflows:
           filters:
             branches:
               ignore:
+                - main
+      - semantic-release/with-changelog-github-config:
+          name: semantic-release
+          requires:
+            - deploy
+          filters:
+            branches:
+              only:
                 - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,29 @@ jobs:
                 root: target/
                 paths:
                   - '*.jar'
+  deploy:
+    executor: java8
+    parameters:
+      version_suffix:
+        type: string
+        default: "-SNAPSHOT"
+        description: Suffix to append to version
+    steps:
+      - checkout
+      - maven/witch-cache:
+          steps:
+            - run:
+                name: Set version to latest tag
+                command: |
+                  export VERSION=$(git describe --dirty --tags 2>/dev/null || git log -1 --pretty=format:%h)
+                  mvn versions:set -DnewVersion="${VERSION}<<parameters.version_suffix>>"
+            - run:
+                name: Import gpg key
+                command: |
+                  echo -e "$GPG_PRIVATE_KEY"  | gpg --import --passphrase "$GPG_PASSPHRASE" --pinentry-mode loopback
+            - run:
+                name: Run maven deploy
+                command: mvn -s .circleci/maven-settings.xml -Dskiptests=true clean deploy
 
 workflows:
   continuous:
@@ -49,3 +72,14 @@ workflows:
       - build:
           requires:
             - test
+      - deploy:
+          version_suffix: "-SNAPSHOT"
+          context:
+            - gpg
+            - maven-central
+          requires:
+            - build
+          filters:
+            branches:
+              ignore:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
     parameters:
       version_suffix:
         type: string
-        default: "-SNAPSHOT"
+        default: ""
         description: Suffix to append to version
     steps:
       - checkout
@@ -74,6 +74,7 @@ workflows:
           requires:
             - test
       - deploy:
+          name: deploy-snapshot
           version_suffix: "-SNAPSHOT"
           context:
             - gpg
@@ -87,8 +88,21 @@ workflows:
       - semantic-release/with-changelog-github-config:
           name: semantic-release
           requires:
-            - deploy
+            - deploy-snapshot
           filters:
             branches:
               only:
                 - main
+      - deploy:
+          context:
+            - gpg
+            - maven-central
+          requires:
+            - build
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /.*/

--- a/.circleci/maven-settings.xml
+++ b/.circleci/maven-settings.xml
@@ -2,8 +2,8 @@
     <servers>
         <server>
             <id>ossrh</id>
-            <username>${env.OSSRH_JIRA_USERNAME}</username>
-            <password>${env.OSSRH_JIRA_PASSWORD}</password>
+            <username>${env.OSSRH_USERNAME}</username>
+            <password>${env.OSSRH_TOKEN}</password>
         </server>
     </servers>
     <profiles>


### PR DESCRIPTION
## Description
Add deployment to maven central.

This includes

- Publish snapshots on feature branches etc
- Publish release on tags triggered by semantic-release later on
