### PR TITLE
ci: Add codecov coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   maven: circleci/maven@1.4.0
   semantic-release: trustedshops-public/semantic-release@3.1.3
+  codecov: codecov/codecov@3.2.4
 
 executors:
   java8:
@@ -19,6 +20,16 @@ executors:
       SPRING_OUTPUT_ANSI_ENABLED: always
 
 jobs:
+  coverage:
+    executor: java11
+    steps:
+      - checkout
+      - maven/with_cache:
+          steps:
+            - run:
+                name: Run tests to record coverage
+                command: mvn test
+            - codecov/upload
   build:
     executor: java8
     steps:
@@ -72,6 +83,9 @@ workflows:
             alias: test
             parameters:
               executor: [ java8, java11 ]
+      - coverage:
+          requires:
+            - test
       - build:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,12 +68,7 @@ jobs:
                   echo -e "$GPG_PRIVATE_KEY"  | gpg --import --passphrase "$GPG_PASSPHRASE" --pinentry-mode loopback
             - run:
                 name: Run maven deploy
-                command: >
-                  mvn 
-                    -s .circleci/maven-settings.xml 
-                    -Possrh 
-                    -DskipTests=true 
-                    clean site javadoc:jar gpg:sign package deploy
+                command: mvn -s .circleci/maven-settings.xml  -Possrh -DskipTests=true clean site javadoc:jar gpg:sign package deploy
 
 workflows:
   continuous:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ spring-boot-starter-keycloak-path-based-resolver
 
 [![CircleCI Build Status](https://circleci.com/gh/trustedshops-public/spring-boot-starter-keycloak-path-based-resolver.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/trustedshops-public/spring-boot-starter-keycloak-path-based-resolver)
 [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://github.com/trustedshops-public/spring-boot-starter-keycloak-path-based-resolver/blob/main/LICENSE)
+[![Quality gate](https://sonarcloud.io/api/project_badges/quality_gate?project=trustedshops-public_spring-boot-starter-keycloak-path-based-resolver)](https://sonarcloud.io/summary/new_code?id=trustedshops-public_spring-boot-starter-keycloak-path-based-resolver)
 
 Spring Boot Starter making it easy to use multiple Keycloak contexts for different parts of your service.
 


### PR DESCRIPTION
## Description
Add codecov.io since we use SonarCloud analysis outside CI not allowing us to capture code coverage.
